### PR TITLE
Fix sample script

### DIFF
--- a/post-commit.sample
+++ b/post-commit.sample
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # An example hook script to log commit messages
 # as a 'daily highlight' in RescueTime Premium

--- a/post-commit.sample
+++ b/post-commit.sample
@@ -27,5 +27,5 @@ LABEL='Code Commit'
 # See more filtering examples in README.md
 
 if [[ ${#MESSAGE} -gt 16 ]]; then
-  curl --data "key=$API_KEY&highlight_date=$DATE_TODAY&description=$MESSAGE&source=$LABEL" https://www.rescuetime.com/anapi/highlights_post
+  curl -XPOST --data "key=$API_KEY&highlight_date=$DATE_TODAY&description=$MESSAGE&source=$LABEL" https://www.rescuetime.com/anapi/highlights_post
 fi


### PR DESCRIPTION
Some fixes for the sample scripts.

First: the if fomat used in the scripts are not supported by `sh`, instead you need to use `bash`.  
Secont: the API call to the current endpoint needs a POST call, as you can see [here](https://www.rescuetime.com/anapi/setup/documentation#highlights-post-reference).
